### PR TITLE
fix line feed（修复换行显示缺失得问题）

### DIFF
--- a/androidwm-light/src/main/java/com/watermark/androidwm_light/utils/BitmapUtils.java
+++ b/androidwm-light/src/main/java/com/watermark/androidwm_light/utils/BitmapUtils.java
@@ -97,7 +97,7 @@ public class BitmapUtils {
         }
         StaticLayout staticLayout = new StaticLayout(watermarkText.getText(),
                 0, watermarkText.getText().length(),
-                watermarkPaint, mTextMaxWidth, android.text.Layout.Alignment.ALIGN_NORMAL, 2.0f,
+                watermarkPaint, mTextMaxWidth, android.text.Layout.Alignment.ALIGN_NORMAL, 1.0f,
                 2.0f, false);
 
         int lineCount = staticLayout.getLineCount();


### PR DESCRIPTION
when spacingmult = 2.0f
![1612689301(1)](https://user-images.githubusercontent.com/11797138/107142189-0bc66a00-6968-11eb-8d9d-c8fe372e5570.jpg)


fix to 1.0f
![1612689380(1)](https://user-images.githubusercontent.com/11797138/107142218-357f9100-6968-11eb-956b-f08d5996e071.jpg)


result:
every '\n' in text ,spacingmult will product n line == spacingmult
fix spacingmult2.0f->1.0f